### PR TITLE
[ENG-741] Facebook rate limit improvements

### DIFF
--- a/Command/MediaCommand.php
+++ b/Command/MediaCommand.php
@@ -43,14 +43,14 @@ class MediaCommand extends ModeratedCommand
                 'date-from',
                 '',
                 InputOption::VALUE_OPTIONAL,
-                'Oldest date to pull spend data for. Leave blank for the last day.',
-                'today'
+                'Oldest date to pull spend data for. Leave blank to pull the last hour or day as needed.',
+                '-1 hour'
             )
             ->addOption(
                 'date-to',
                 '',
                 InputOption::VALUE_OPTIONAL,
-                'Newest date to pull spend data for. Leave blank for current date.',
+                'Newest date to pull spend data for. Leave blank for the current date.',
                 'now'
             )
             ->addOption(
@@ -87,8 +87,8 @@ class MediaCommand extends ModeratedCommand
         }
         $limit          = $input->getOption('limit');
         $mediaAccountId = $input->getOption('media-account');
-        $dateFrom       = new \DateTime($input->getOption('date-from'));
-        $dateTo         = new \DateTime($input->getOption('date-to'));
+        $dateFromString = $input->getOption('date-from');
+        $dateToString   = $input->getOption('date-to');
         $provider       = strtolower($input->getOption('provider'));
 
         /** @var MediaAccountModel $model */
@@ -134,7 +134,7 @@ class MediaCommand extends ModeratedCommand
                 continue;
             }
             $output->writeln('<info>Pulling data for Media Account '.$mediaAccount->getName().'</info>');
-            $model->pullData($mediaAccount, $dateFrom, $dateTo, $output);
+            $model->pullData($mediaAccount, $dateFromString, $dateToString, $output);
         }
 
         $this->completeRun();

--- a/Command/MediaCommand.php
+++ b/Command/MediaCommand.php
@@ -44,7 +44,7 @@ class MediaCommand extends ModeratedCommand
                 '',
                 InputOption::VALUE_OPTIONAL,
                 'Oldest date to pull spend data for. Leave blank for the last day.',
-                '-1 day'
+                'today'
             )
             ->addOption(
                 'date-to',

--- a/Helper/CommonProviderHelper.php
+++ b/Helper/CommonProviderHelper.php
@@ -113,6 +113,7 @@ class CommonProviderHelper
         $this->output                 = $output;
         $this->em                     = $em;
         $this->campaignSettingsHelper = $campaignSettingsHelper;
+        ini_set('max_execution_time', 0);
     }
 
     /**

--- a/Model/MediaAccountModel.php
+++ b/Model/MediaAccountModel.php
@@ -378,17 +378,17 @@ class MediaAccountModel extends FormModel
     }
 
     /**
-     * @param MediaAccount|null $mediaAccount
-     * @param \DateTime         $dateFrom
-     * @param \DateTime         $dateTo
-     * @param OutputInterface   $output
+     * @param MediaAccount    $mediaAccount
+     * @param string          $dateFromString
+     * @param string          $dateToString
+     * @param OutputInterface $output
      *
-     * @throws \Exception
+     * @throws \Doctrine\ORM\ORMException
      */
     public function pullData(
         MediaAccount $mediaAccount,
-        \DateTime $dateFrom,
-        \DateTime $dateTo,
+        $dateFromString,
+        $dateToString,
         OutputInterface $output
     ) {
         $helper = $this->getProviderHelper($mediaAccount, $output, $this->em, true);
@@ -399,8 +399,8 @@ class MediaAccountModel extends FormModel
                     date_default_timezone_get()
                 )
             );
-            $dateFrom->setTimezone($timezone);
-            $dateTo->setTimezone($timezone);
+            $dateFrom = new \DateTime($dateFromString, $timezone);
+            $dateTo   = new \DateTime($dateToString, $timezone);
             $dateFrom->setTime(0, 0, 0, 0);
             $dateTo->setTime(0, 0, 0, 0);
             $helper->pullData($dateFrom, $dateTo);

--- a/Model/MediaAccountModel.php
+++ b/Model/MediaAccountModel.php
@@ -212,7 +212,6 @@ class MediaAccountModel extends FormModel
         $query = new ChartQuery($this->em->getConnection(), $dateFrom, $dateTo, $unit);
         $unit  = (null === $unit) ? $this->getTimeUnitFromDateRange($dateFrom, $dateTo) : $unit;
         $chart = new LineChart($unit, $dateFrom, $dateTo, $dateFormat);
-        $sets  = 0;
 
         $params = [
             'media_account_id' => $MediaAccount->getId(),
@@ -279,26 +278,8 @@ class MediaAccountModel extends FormModel
 
             $data = $query->loadAndBuildTimeData($q);
             foreach ($data as $key => $val) {
-                if (!isset($totals[$key])) {
-                    $totals[$key] = 0;
-                }
-                $totals[$key] += $val;
-            }
-            foreach ($data as $key => $val) {
                 if (0 !== $val) {
                     $chart->setDataset($providerAccountName, $data);
-                    break;
-                }
-            }
-            ++$sets;
-        }
-        if ($sets > 1) {
-            foreach ($totals as $val) {
-                if (0 !== $val) {
-                    $chart->setDataset(
-                        $this->translator->trans('mautic.media.form.provider.total.'.$MediaAccount->getProvider()),
-                        $totals
-                    );
                     break;
                 }
             }


### PR DESCRIPTION
Previous version could get a “today” date wrong based on timezones.

This also refactors rate limit handling, and allows for better failover in Facebook.

The default cron tasks are now simpler, automatically pulling in the previous day if the cron is running during the "0" hour.